### PR TITLE
Github Action Changelog Generation 

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,7 +22,7 @@ jobs:
             rm changelog.txt
           fi
           
-          git --no-pager tag --sort=-creatordate --merged main | while read -r tag ; do
+          git --no-pager tag --sort=-creatordate --merged origin/main | while read -r tag ; do
             echo "---------------------------------------------------------------------------------------------------" >> changelog.txt
             echo "Version: $tag" >> changelog.txt
             echo "$(git --no-pager log --pretty=%ad --date=format:'Date: %m. %d. %Y' -1 $tag)" >> changelog.txt


### PR DESCRIPTION
* Adding `origin` to the tag list for building the changelog. This is due to errors in how the Github Runners handle the local repository.